### PR TITLE
Publish to sbt-plugin-releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Add plugin
 Add the plugin to `project/plugins.sbt`. For example:
 
 ```scala
-resolvers += "Bintray repository" at "http://dl.bintray.com/neomaclin/maven/"
-
 addSbtPlugin("com.nurun.sbt" % "sbt-simple-url-update" % "1.0.0")
 ```
 


### PR DESCRIPTION
Hi, not sure if you're still maintaining this, but there's a small change which would make this plugin easier to use. If you get the plugin included in the main repository `sbt-plugin-releases`, users won't need to add an extra resolver to their build.

I can't do it for you, but it should be easy since you're already published to bintray. All you have to do is click a button and wait for an admin to approve it. Then you can merge this PR. There are official instructions [here](http://www.scala-sbt.org/0.13/docs/Bintray-For-Plugins.html#Linking+your+package+to+the+sbt+organization).